### PR TITLE
add Mapstruct and google java format to exam service

### DIFF
--- a/j-exam-service-do-online-exam/pom.xml
+++ b/j-exam-service-do-online-exam/pom.xml
@@ -90,6 +90,11 @@
 			<artifactId>pdfbox</artifactId>
 			<version>2.0.26</version>
 		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.3.Final</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -99,6 +104,11 @@
 				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.google.googlejavaformat</groupId>
+				<artifactId>google-java-format</artifactId>
+				<version>5.14.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -115,6 +125,46 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5</version>
+				<configuration>
+					<source>17</source>
+					<target>17</target>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.3.Final</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>2.37.0</version>
+				<configuration>
+					<formats>
+						<format>
+							<includes>
+								<include>*.java</include>
+							</includes>
+							<trimTrailingWhitespace/>
+							<endWithNewline/>
+							<indent>
+								<tabs>true</tabs>
+								<spacesPerTab>4</spacesPerTab>
+							</indent>
+						</format>
+					</formats>
+					<java>
+						<googleJavaFormat/>
+						<indent><tabs>true</tabs><spacesPerTab>2</spacesPerTab></indent>
+					</java>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Để chạy autoformat:
exam-service / Plugins / spotless / spotless:apply

Để chạy verify:
exam-service / Plugins / spotless / spotless:check
![image](https://github.com/Nam07081994/J-Micro-Do-Online-Exam-Back-End/assets/116781092/277a5a1b-3e80-440a-b97e-088069f88ed2)
